### PR TITLE
feat: adiciona filtros avançados no Kanban e modal de visualizacao/ed…

### DIFF
--- a/apps/supervisor/src/components/routes/pedidos/Kanban.tsx
+++ b/apps/supervisor/src/components/routes/pedidos/Kanban.tsx
@@ -1,19 +1,169 @@
-"use client";
+// "use client";
 
-import React, { useMemo, useState } from "react";
-import { Checkbox } from "@supervisor/components/ui/checkbox";
-import { PedidoKanban, PedidoStatus } from "@supervisor/types/pedido";
-import { KanbanColuna } from "./KanbanColuna";
-import { FooterSelecionados } from "./SuspenseFooter";
-import {
-  useFetchPedidosAdminKanban,
-  useMutatePedidoAdmin,
-} from "@supervisor/services/useQueryPedidoAdmin";
-import { format } from "date-fns";
-import { DatePicker } from "../../shared/DatePicker";
+// import React, { useMemo, useState } from "react";
+// import { Checkbox } from "@supervisor/components/ui/checkbox";
+// import { PedidoKanban, PedidoStatus } from "@supervisor/types/pedido";
+// import { KanbanColuna } from "./KanbanColuna";
+// import { FooterSelecionados } from "./SuspenseFooter";
+// import {
+//   useFetchPedidosAdminKanban,
+//   useMutatePedidoAdmin,
+// } from "@supervisor/services/useQueryPedidoAdmin";
+// import { format } from "date-fns";
+// import { DatePicker } from "../../shared/DatePicker";
+
+// // ---------------- Status Map ----------------
+// export type StatusMeta = { label: string; headerClass: string };
+
+// export const statusMap: Record<PedidoStatus, StatusMeta> = {
+//   P: { label: "Pendente", headerClass: "bg-yellow-500 text-white" },
+//   R: { label: "Em preparo", headerClass: "bg-purple-600 text-white" },
+//   S: {
+//     label: "Saiu para entrega",
+//     headerClass: "bg-[hsl(var(--primary))] text-white",
+//   },
+//   E: { label: "Entregue", headerClass: "bg-green-600 text-white" }, 
+//   C: { label: "Cancelado", headerClass: "bg-red-600 text-white" },
+// };
+
+// // ---------------- KanbanPedidos ----------------
+// const KanbanPedidos = () => {
+//   const hoje = new Date();
+//   const [selectedDay, setSelectedDay] = useState<Date>(hoje);
+
+//   // formatamos no padrão que o backend espera (YYYY-MM-DD)
+//   const selectedDate = format(selectedDay, "yyyy-MM-dd");
+
+//   const [selecionados, setSelecionados] = useState<Set<number>>(new Set());
+//   const [colunasVisiveis, setColunasVisiveis] = useState<
+//     Record<PedidoStatus, boolean>
+//   >(() =>
+//     Object.keys(statusMap).reduce(
+//       (acc, key) => ({ ...acc, [key]: true }),
+//       {} as Record<PedidoStatus, boolean>
+//     )
+//   );
+
+//   const { data: pedidos = [], isLoading } =
+//     useFetchPedidosAdminKanban(selectedDate);
+//   const { atualizarStatus } = useMutatePedidoAdmin();
+
+//   // ---------------- Agrupando pedidos por status ----------------
+//   const pedidosPorStatus = useMemo(() => {
+//     const agrupados: Record<PedidoStatus, PedidoKanban[]> =
+//       {} as Record<PedidoStatus, PedidoKanban[]>;
+//     (Object.keys(statusMap) as PedidoStatus[]).forEach(
+//       (s) => (agrupados[s] = [])
+//     );
+//     pedidos.forEach((pedido) => {
+//       agrupados[pedido.status]?.push(pedido);
+//     });
+//     return agrupados;
+//   }, [pedidos]);
+
+//   const toggleSelecionado = (id: number) => {
+//     setSelecionados((prev) => {
+//       const novo = new Set(prev);
+//       novo.has(id) ? novo.delete(id) : novo.add(id);
+//       return novo;
+//     });
+//   };
+
+//   const handleToggleColuna = (key: PedidoStatus) => {
+//     setColunasVisiveis((prev) => ({ ...prev, [key]: !prev[key] }));
+//   };
+
+//   const handleMoverSelecionados = (novoStatus: PedidoStatus) => {
+//     selecionados.forEach((id) =>
+//       atualizarStatus.mutate({ id, status: novoStatus })
+//     );
+//     setSelecionados(new Set());
+//   };
+
+//   const handleCancelarSelecionados = () => setSelecionados(new Set());
+
+//   if (isLoading) return <p>Carregando pedidos...</p>;
+
+//   return (
+//     <div className="h-[calc(100vh-100px)] flex flex-col p-4 space-y-4">
+//       {/* Filtro por Data */}
+
+//       {/* Filtro de colunas */}
+//       <div className="flex justify-between">
+//         <div className="flex flex-wrap gap-4 items-center">
+//         {Object.entries(statusMap).map(([key, meta]) => (
+//           <label
+//           key={key}
+//           className="flex items-center gap-2 text-sm cursor-pointer"
+//           >
+//             <Checkbox
+//               checked={colunasVisiveis[key as PedidoStatus]}
+//               onCheckedChange={() => handleToggleColuna(key as PedidoStatus)}
+//             />
+//             <span className="px-2 py-1 rounded-full text-xs font-semibold bg-slate-200 text-primary">
+//               {meta.label}
+//             </span>
+//           </label>
+//         ))}
+//         </div>
+//         <DatePicker date={selectedDay} onChange={setSelectedDay} />
+//       </div>
+
+//       {/* Colunas do Kanban */}
+//       <div className="flex-1 overflow-x-auto">
+//         <div className="flex gap-4 h-full">
+//           {Object.entries(statusMap)
+//             .filter(([key]) => colunasVisiveis[key as PedidoStatus])
+//             .map(([statusKey, meta]) => (
+//               <KanbanColuna
+//                 key={statusKey}
+//                 statusMeta={meta}
+//                 pedidos={pedidosPorStatus[statusKey as PedidoStatus] || []}
+//                 selecionados={selecionados}
+//                 onToggleSelecionado={toggleSelecionado}
+//                 selectedDate={selectedDate}
+//               />
+//             ))}
+//         </div>
+//       </div>
+
+//       {/* Footer de ações */}
+//       {selecionados.size > 0 && (
+//         <FooterSelecionados
+//           count={selecionados.size}
+//           onMoverSelecionados={handleMoverSelecionados}
+//           onCancelar={handleCancelarSelecionados}
+//           visivel={selecionados.size > 0}
+//         />
+//       )}
+//     </div>
+//   );
+// };
+
+// export default KanbanPedidos;
+
+
+"use client"
+
+import { useMemo, useState } from "react"
+import { Checkbox } from "@supervisor/components/ui/checkbox"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@supervisor/components/ui/select"
+import { Badge } from "@supervisor/components/ui/badge"
+import { Button } from "@supervisor/components/ui/button"
+import type { PedidoKanban, PedidoStatus } from "@supervisor/types/pedido"
+import { KanbanColuna } from "./KanbanColuna"
+import { FooterSelecionados } from "./SuspenseFooter"
+import { useFetchPedidosAdminKanban, useMutatePedidoAdmin } from "@supervisor/services/useQueryPedidoAdmin"
+import { useEmpresas } from "@supervisor/services/useQueryEmpresasMensura"
+import { useCurrentUser } from "@supervisor/services/useCurrentUser"
+import { format } from "date-fns"
+import { DatePicker } from "../../shared/DatePicker"
+import { Input } from "@supervisor/components/ui/input"
+import { Label } from "@supervisor/components/ui/label"
+import { Search, Filter, X, Calendar, User, Phone, Hash, Truck, Building2 } from "lucide-react"
 
 // ---------------- Status Map ----------------
-export type StatusMeta = { label: string; headerClass: string };
+export type StatusMeta = { label: string; headerClass: string }
 
 export const statusMap: Record<PedidoStatus, StatusMeta> = {
   P: { label: "Pendente", headerClass: "bg-yellow-500 text-white" },
@@ -22,94 +172,376 @@ export const statusMap: Record<PedidoStatus, StatusMeta> = {
     label: "Saiu para entrega",
     headerClass: "bg-[hsl(var(--primary))] text-white",
   },
-  E: { label: "Entregue", headerClass: "bg-green-600 text-white" }, 
+  E: { label: "Entregue", headerClass: "bg-green-600 text-white" },
   C: { label: "Cancelado", headerClass: "bg-red-600 text-white" },
-};
+}
+
+// ---------------- FiltrosAvancados ----------------
+const FiltrosAvancados = ({
+  filtros,
+  setFiltros,
+  colunasVisiveis,
+  pedidos,
+  onLimparFiltros,
+}: {
+  filtros: any
+  setFiltros: any
+  colunasVisiveis: Record<PedidoStatus, boolean>
+  pedidos: PedidoKanban[]
+  onLimparFiltros: () => void
+}) => {
+  const { data: empresas = [] } = useEmpresas()
+  const { data: currentUser } = useCurrentUser()
+
+  const empresasDisponiveis = useMemo(() => {
+    if (!currentUser?.empresa_ids || currentUser.empresa_ids.length === 0) {
+      return empresas
+    }
+    return empresas.filter((empresa) => currentUser.empresa_ids!.includes(empresa.id))
+  }, [empresas, currentUser])
+
+  const motoboyOptions = useMemo(() => {
+    const motoboys = new Set<string>()
+    pedidos.forEach((pedido) => {
+      if (pedido.motoboy && (pedido.status === "S" || pedido.status === "E")) {
+        motoboys.add(pedido.motoboy)
+      }
+    })
+    return Array.from(motoboys).sort()
+  }, [pedidos])
+
+  const filtrosAtivos = Object.values(filtros).filter(Boolean).length
+
+  return (
+    <div className="bg-white border rounded-lg p-6 space-y-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Filter className="h-5 w-5 text-primary" />
+            <h3 className="text-lg font-semibold">Filtros Avançados</h3>
+          </div>
+          {filtrosAtivos > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {filtrosAtivos} ativo{filtrosAtivos > 1 ? "s" : ""}
+            </Badge>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onLimparFiltros}
+          className="text-muted-foreground hover:text-foreground bg-transparent"
+        >
+          <X className="h-4 w-4 mr-2" />
+          Limpar filtros
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="numeroPedido" className="flex items-center gap-2 text-sm font-medium">
+            <Hash className="h-4 w-4 text-muted-foreground" />
+            Número do Pedido
+          </Label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="numeroPedido"
+              placeholder="Ex: 123"
+              value={filtros.numeroPedido}
+              onChange={(e) => setFiltros((prev: any) => ({ ...prev, numeroPedido: e.target.value }))}
+              className="pl-10 py-3"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="telefoneCliente" className="flex items-center gap-2 text-sm font-medium">
+            <Phone className="h-4 w-4 text-muted-foreground" />
+            Telefone do Cliente
+          </Label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="telefoneCliente"
+              placeholder="Ex: (11) 99999-9999"
+              value={filtros.telefoneCliente}
+              onChange={(e) => setFiltros((prev: any) => ({ ...prev, telefoneCliente: e.target.value }))}
+              className="pl-10 py-3"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="nomeCliente" className="flex items-center gap-2 text-sm font-medium">
+            <User className="h-4 w-4 text-muted-foreground" />
+            Nome do Cliente
+          </Label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="nomeCliente"
+              placeholder="Ex: João Silva"
+              value={filtros.nomeCliente}
+              onChange={(e) => setFiltros((prev: any) => ({ ...prev, nomeCliente: e.target.value }))}
+              className="pl-10 py-3"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label className="flex items-center gap-2 text-sm font-medium">
+            <Building2 className="h-4 w-4 text-muted-foreground" />
+            Empresa
+          </Label>
+          <Select
+            value={filtros.empresa}
+            onValueChange={(value) => setFiltros((prev: any) => ({ ...prev, empresa: value }))}
+          >
+            <SelectTrigger className="w-full py-3">
+              <SelectValue placeholder="Selecione uma empresa" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todas as empresas</SelectItem>
+              {empresasDisponiveis.map((empresa) => (
+                <SelectItem key={empresa.id} value={empresa.id.toString()}>
+                  {empresa.nome}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <Label className="flex items-center gap-2 text-sm font-medium">
+            <Truck className="h-4 w-4 text-muted-foreground" />
+            Motoboy
+          </Label>
+          <Select
+            value={filtros.motoboy}
+            onValueChange={(value) => setFiltros((prev: any) => ({ ...prev, motoboy: value }))}
+            disabled={!colunasVisiveis.S && !colunasVisiveis.E}
+          >
+            <SelectTrigger className="w-full py-3">
+              <SelectValue placeholder="Selecione um motoboy" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os motoboys</SelectItem>
+              {motoboyOptions.map((motoboy) => (
+                <SelectItem key={motoboy} value={motoboy}>
+                  {motoboy}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!colunasVisiveis.S && !colunasVisiveis.E && (
+            <p className="text-xs text-muted-foreground flex items-center gap-1">
+              <Calendar className="h-3 w-3" />
+              Disponível apenas para "Saiu para entrega" e "Entregue"
+            </p>
+          )}
+        </div>
+      </div>
+
+      {filtrosAtivos > 0 && (
+        <div className="flex flex-wrap gap-2 pt-4 border-t">
+          <span className="text-sm text-muted-foreground">Filtros ativos:</span>
+          {filtros.numeroPedido && (
+            <Badge variant="outline" className="gap-1">
+              <Hash className="h-3 w-3" />
+              Pedido: {filtros.numeroPedido}
+              <X
+                className="h-3 w-3 cursor-pointer hover:text-destructive"
+                onClick={() => setFiltros((prev: any) => ({ ...prev, numeroPedido: "" }))}
+              />
+            </Badge>
+          )}
+          {filtros.telefoneCliente && (
+            <Badge variant="outline" className="gap-1">
+              <Phone className="h-3 w-3" />
+              Tel: {filtros.telefoneCliente}
+              <X
+                className="h-3 w-3 cursor-pointer hover:text-destructive"
+                onClick={() => setFiltros((prev: any) => ({ ...prev, telefoneCliente: "" }))}
+              />
+            </Badge>
+          )}
+          {filtros.nomeCliente && (
+            <Badge variant="outline" className="gap-1">
+              <User className="h-3 w-3" />
+              Nome: {filtros.nomeCliente}
+              <X
+                className="h-3 w-3 cursor-pointer hover:text-destructive"
+                onClick={() => setFiltros((prev: any) => ({ ...prev, nomeCliente: "" }))}
+              />
+            </Badge>
+          )}
+          {filtros.empresa && filtros.empresa !== "all" && (
+            <Badge variant="outline" className="gap-1">
+              <Building2 className="h-3 w-3" />
+              Empresa: {empresasDisponiveis.find((e) => e.id.toString() === filtros.empresa)?.nome}
+              <X
+                className="h-3 w-3 cursor-pointer hover:text-destructive"
+                onClick={() => setFiltros((prev: any) => ({ ...prev, empresa: "" }))}
+              />
+            </Badge>
+          )}
+          {filtros.motoboy && filtros.motoboy !== "all" && (
+            <Badge variant="outline" className="gap-1">
+              <Truck className="h-3 w-3" />
+              Motoboy: {filtros.motoboy}
+              <X
+                className="h-3 w-3 cursor-pointer hover:text-destructive"
+                onClick={() => setFiltros((prev: any) => ({ ...prev, motoboy: "" }))}
+              />
+            </Badge>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // ---------------- KanbanPedidos ----------------
 const KanbanPedidos = () => {
-  const hoje = new Date();
-  const [selectedDay, setSelectedDay] = useState<Date>(hoje);
+  const hoje = new Date()
+  const [selectedDay, setSelectedDay] = useState<Date>(hoje)
 
-  // formatamos no padrão que o backend espera (YYYY-MM-DD)
-  const selectedDate = format(selectedDay, "yyyy-MM-dd");
+  const selectedDate = format(selectedDay, "yyyy-MM-dd")
 
-  const [selecionados, setSelecionados] = useState<Set<number>>(new Set());
-  const [colunasVisiveis, setColunasVisiveis] = useState<
-    Record<PedidoStatus, boolean>
-  >(() =>
-    Object.keys(statusMap).reduce(
-      (acc, key) => ({ ...acc, [key]: true }),
-      {} as Record<PedidoStatus, boolean>
-    )
-  );
+  const [selecionados, setSelecionados] = useState<Set<number>>(new Set())
+  const [colunasVisiveis, setColunasVisiveis] = useState<Record<PedidoStatus, boolean>>(() =>
+    Object.keys(statusMap).reduce((acc, key) => ({ ...acc, [key]: true }), {} as Record<PedidoStatus, boolean>),
+  )
 
-  const { data: pedidos = [], isLoading } =
-    useFetchPedidosAdminKanban(selectedDate);
-  const { atualizarStatus } = useMutatePedidoAdmin();
+  const [filtros, setFiltros] = useState({
+    numeroPedido: "",
+    telefoneCliente: "",
+    nomeCliente: "",
+    empresa: "all",
+    motoboy: "all",
+  })
 
-  // ---------------- Agrupando pedidos por status ----------------
+  const { data: empresas = [] } = useEmpresas()
+  const { data: currentUser } = useCurrentUser()
+
+  const empresasDisponiveis = useMemo(() => {
+    if (!currentUser?.empresa_ids || currentUser.empresa_ids.length === 0) {
+      return empresas
+    }
+    return empresas.filter((empresa) => currentUser.empresa_ids!.includes(empresa.id))
+  }, [empresas, currentUser])
+
+  const empresaIdParam = useMemo(() => {
+    if (filtros.empresa === "all") {
+      return empresasDisponiveis[0]?.id?.toString()
+    }
+    return filtros.empresa
+  }, [filtros.empresa, empresasDisponiveis])
+
+  const { data: pedidos = [], isLoading } = useFetchPedidosAdminKanban(selectedDate, empresaIdParam)
+  const { atualizarStatus } = useMutatePedidoAdmin()
+
   const pedidosPorStatus = useMemo(() => {
-    const agrupados: Record<PedidoStatus, PedidoKanban[]> =
-      {} as Record<PedidoStatus, PedidoKanban[]>;
-    (Object.keys(statusMap) as PedidoStatus[]).forEach(
-      (s) => (agrupados[s] = [])
-    );
-    pedidos.forEach((pedido) => {
-      agrupados[pedido.status]?.push(pedido);
-    });
-    return agrupados;
-  }, [pedidos]);
+    const pedidosFiltrados = pedidos.filter((pedido) => {
+      if (filtros.numeroPedido && !pedido.id.toString().includes(filtros.numeroPedido)) {
+        return false
+      }
+
+      if (
+        filtros.telefoneCliente &&
+        !pedido.telefone_cliente?.toLowerCase().includes(filtros.telefoneCliente.toLowerCase())
+      ) {
+        return false
+      }
+
+      if (filtros.nomeCliente && !pedido.nome_cliente?.toLowerCase().includes(filtros.nomeCliente.toLowerCase())) {
+        return false
+      }
+
+      // Removed filtro por empresa_id pois agora é feito na API
+      // if (filtros.empresa !== "all" && pedido.empresa_id?.toString() !== filtros.empresa) {
+      //   return false
+      // }
+
+      if (filtros.motoboy !== "all" && (pedido.status === "S" || pedido.status === "E")) {
+        if (!pedido.motoboy?.toLowerCase().includes(filtros.motoboy.toLowerCase())) {
+          return false
+        }
+      }
+
+      return true
+    })
+
+    const agrupados: Record<PedidoStatus, PedidoKanban[]> = {} as Record<PedidoStatus, PedidoKanban[]>
+    ;(Object.keys(statusMap) as PedidoStatus[]).forEach((s) => (agrupados[s] = []))
+    pedidosFiltrados.forEach((pedido) => {
+      agrupados[pedido.status]?.push(pedido)
+    })
+    return agrupados
+  }, [pedidos, filtros])
 
   const toggleSelecionado = (id: number) => {
     setSelecionados((prev) => {
-      const novo = new Set(prev);
-      novo.has(id) ? novo.delete(id) : novo.add(id);
-      return novo;
-    });
-  };
+      const novo = new Set(prev)
+      novo.has(id) ? novo.delete(id) : novo.add(id)
+      return novo
+    })
+  }
 
   const handleToggleColuna = (key: PedidoStatus) => {
-    setColunasVisiveis((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
+    setColunasVisiveis((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
 
   const handleMoverSelecionados = (novoStatus: PedidoStatus) => {
-    selecionados.forEach((id) =>
-      atualizarStatus.mutate({ id, status: novoStatus })
-    );
-    setSelecionados(new Set());
-  };
+    selecionados.forEach((id) => atualizarStatus.mutate({ id, status: novoStatus }))
+    setSelecionados(new Set())
+  }
 
-  const handleCancelarSelecionados = () => setSelecionados(new Set());
+  const handleCancelarSelecionados = () => setSelecionados(new Set())
 
-  if (isLoading) return <p>Carregando pedidos...</p>;
+  const limparFiltros = () => {
+    setFiltros({
+      numeroPedido: "",
+      telefoneCliente: "",
+      nomeCliente: "",
+      empresa: "all",
+      motoboy: "all",
+    })
+  }
+
+  if (isLoading) return <p>Carregando pedidos...</p>
 
   return (
     <div className="h-[calc(100vh-100px)] flex flex-col p-4 space-y-4">
-      {/* Filtro por Data */}
+      <FiltrosAvancados
+        filtros={filtros}
+        setFiltros={setFiltros}
+        colunasVisiveis={colunasVisiveis}
+        pedidos={pedidos}
+        onLimparFiltros={limparFiltros}
+      />
 
-      {/* Filtro de colunas */}
       <div className="flex justify-between">
         <div className="flex flex-wrap gap-4 items-center">
-        {Object.entries(statusMap).map(([key, meta]) => (
-          <label
-          key={key}
-          className="flex items-center gap-2 text-sm cursor-pointer"
-          >
-            <Checkbox
-              checked={colunasVisiveis[key as PedidoStatus]}
-              onCheckedChange={() => handleToggleColuna(key as PedidoStatus)}
-            />
-            <span className="px-2 py-1 rounded-full text-xs font-semibold bg-slate-200 text-primary">
-              {meta.label}
-            </span>
-          </label>
-        ))}
+          {Object.entries(statusMap).map(([key, meta]) => (
+            <label key={key} className="flex items-center gap-2 text-sm cursor-pointer">
+              <Checkbox
+                checked={colunasVisiveis[key as PedidoStatus]}
+                onCheckedChange={() => handleToggleColuna(key as PedidoStatus)}
+              />
+              <span className="px-2 py-1 rounded-full text-xs font-semibold bg-slate-200 text-primary">
+                {meta.label}
+              </span>
+            </label>
+          ))}
         </div>
-        <DatePicker date={selectedDay} onChange={setSelectedDay} />
+        <div className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
+          <DatePicker date={selectedDay} onChange={setSelectedDay} />
+        </div>
       </div>
 
-      {/* Colunas do Kanban */}
       <div className="flex-1 overflow-x-auto">
         <div className="flex gap-4 h-full">
           {Object.entries(statusMap)
@@ -127,7 +559,6 @@ const KanbanPedidos = () => {
         </div>
       </div>
 
-      {/* Footer de ações */}
       {selecionados.size > 0 && (
         <FooterSelecionados
           count={selecionados.size}
@@ -137,7 +568,7 @@ const KanbanPedidos = () => {
         />
       )}
     </div>
-  );
-};
+  )
+}
 
-export default KanbanPedidos;
+export default KanbanPedidos

--- a/apps/supervisor/src/components/routes/pedidos/PedidoCard.tsx
+++ b/apps/supervisor/src/components/routes/pedidos/PedidoCard.tsx
@@ -1,87 +1,183 @@
-import { PedidoKanban } from "@supervisor/types/pedido";
-import React from "react";
-import { statusMap } from "./Kanban";
-import TempoPedidoBadge from "./TempoPedidoBadge";
-import { Checkbox } from "@supervisor/components/ui/checkbox";
-import { isToday, parseISO } from "date-fns";
-import { Button } from "@supervisor/components/ui/button";
-import { ChevronRight, CircleArrowRight, Eye, Printer } from "lucide-react";
+// import { PedidoKanban } from "@supervisor/types/pedido";
+// import React from "react";
+// import { statusMap } from "./Kanban";
+// import TempoPedidoBadge from "./TempoPedidoBadge";
+// import { Checkbox } from "@supervisor/components/ui/checkbox";
+// import { isToday, parseISO } from "date-fns";
+// import { Button } from "@supervisor/components/ui/button";
+// import { ChevronRight, CircleArrowRight, Eye, Printer } from "lucide-react";
+
+// export const PedidoCard = React.memo(
+//   ({
+//     pedido,
+//     selecionado,
+//     onToggleSelecionado,
+//     selectedDate, // <- adicionamos aqui
+//   }: {
+//     pedido: PedidoKanban;
+//     selecionado: boolean;
+//     onToggleSelecionado: (id: number) => void;
+//     selectedDate: string; // formato "yyyy-MM-dd"
+//   }) => {
+//     const mostrarTempoBadge =
+//       pedido.status !== "C" &&
+//       pedido.status !== "E" &&
+//       isToday(parseISO(selectedDate));
+
+//     return (
+//       <div className="bg-white border rounded-lg p-3 shadow-sm hover:shadow-md transition flex flex-col gap-2 text-sm">
+//         {/* Header */}
+//         <div className="flex items-center gap-2">
+//           <Checkbox
+//             checked={selecionado}
+//             onCheckedChange={() => onToggleSelecionado(pedido.id)}
+//           />
+//           <div className="flex justify-between w-full">
+//             <div className="flex gap-2">
+//               <p className="font-semibold text-primary ">#{pedido.id}</p>
+//               <p className="text-muted-foreground">{pedido.nome_cliente || "—"}</p>
+//             </div>
+//             <div className="flex mt-auto gap-2">
+//               {mostrarTempoBadge && (
+//                 <TempoPedidoBadge
+//                   dataCriacao={pedido.data_criacao}
+//                   limiteMinutos={30}
+//                   />
+//                 )}
+//             </div>
+//           </div>
+//         </div>
+
+//         {/* Informações do cliente */}
+//         <div className="text-sm text-muted-foreground flex flex-col gap-1">
+//           <span>
+//             <strong>Telefone:</strong> {pedido.telefone_cliente || "—"}
+//           </span>
+//           {pedido.endereco_cliente && (
+//             <span>
+//               <strong>Endereço:</strong> {pedido.endereco_cliente}
+//             </span>
+//           )}
+//           <span>
+//             <strong>Meio de Pagamento:</strong>{" "}
+//             {pedido.meio_pagamento_descricao || "—"}
+//           </span>
+//         </div>
+
+//         {/* Valor total */}
+//         <div className=" flex justify-between font-bold text-foreground">
+//           R$ {pedido.valor_total.toFixed(2)}
+//           <div className="flex gap-1">
+//             <button className="bg-primary/20 text-primary rounded-full d px-2">
+//               <Eye size={15} />
+//             </button>
+//             <button className="bg-primary/20 text-primary rounded-full px-2">
+//               <Printer size={15} />
+//             </button>
+//             <button className="bg-primary/20 text-primary rounded-full px-2">
+//               <ChevronRight size={15} />
+//             </button>
+//           </div>
+//         </div>
+//       </div>
+//     );
+//   }
+// );
+
+// PedidoCard.displayName = "PedidoCard";
+
+
+
+
+"use client"
+
+import type { PedidoKanban } from "@supervisor/types/pedido"
+import React, { useState } from "react"
+import TempoPedidoBadge from "./TempoPedidoBadge"
+import { PedidoModal } from "./PedidoModal"
+import { Checkbox } from "@supervisor/components/ui/checkbox"
+import { isToday, parseISO } from "date-fns"
+import { ChevronRight, Eye, Printer } from "lucide-react"
 
 export const PedidoCard = React.memo(
   ({
     pedido,
     selecionado,
     onToggleSelecionado,
-    selectedDate, // <- adicionamos aqui
+    selectedDate,
   }: {
-    pedido: PedidoKanban;
-    selecionado: boolean;
-    onToggleSelecionado: (id: number) => void;
-    selectedDate: string; // formato "yyyy-MM-dd"
+    pedido: PedidoKanban
+    selecionado: boolean
+    onToggleSelecionado: (id: number) => void
+    selectedDate: string
   }) => {
-    const mostrarTempoBadge =
-      pedido.status !== "C" &&
-      pedido.status !== "E" &&
-      isToday(parseISO(selectedDate));
+    const [isModalOpen, setIsModalOpen] = useState(false)
+
+    const mostrarTempoBadge = pedido.status !== "C" && pedido.status !== "E" && isToday(parseISO(selectedDate))
 
     return (
-      <div className="bg-white border rounded-lg p-3 shadow-sm hover:shadow-md transition flex flex-col gap-2 text-sm">
-        {/* Header */}
-        <div className="flex items-center gap-2">
-          <Checkbox
-            checked={selecionado}
-            onCheckedChange={() => onToggleSelecionado(pedido.id)}
-          />
-          <div className="flex justify-between w-full">
-            <div className="flex gap-2">
-              <p className="font-semibold text-primary ">#{pedido.id}</p>
-              <p className="text-muted-foreground">{pedido.nome_cliente || "—"}</p>
-            </div>
-            <div className="flex mt-auto gap-2">
-              {mostrarTempoBadge && (
-                <TempoPedidoBadge
-                  dataCriacao={pedido.data_criacao}
-                  limiteMinutos={30}
-                  />
-                )}
+      <>
+        <div className="bg-white border rounded-lg p-3 shadow-sm hover:shadow-md transition flex flex-col gap-2 text-sm">
+          {/* Header */}
+          <div className="flex items-center gap-2">
+            <Checkbox checked={selecionado} onCheckedChange={() => onToggleSelecionado(pedido.id)} />
+            <div className="flex justify-between w-full">
+              <div className="flex gap-2">
+                <p className="font-semibold text-primary ">#{pedido.id}</p>
+                <p className="text-muted-foreground">{pedido.nome_cliente || "—"}</p>
+              </div>
+              <div className="flex mt-auto gap-2">
+                {mostrarTempoBadge && <TempoPedidoBadge dataCriacao={pedido.data_criacao} limiteMinutos={30} />}
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Informações do cliente */}
-        <div className="text-sm text-muted-foreground flex flex-col gap-1">
-          <span>
-            <strong>Telefone:</strong> {pedido.telefone_cliente || "—"}
-          </span>
-          {pedido.endereco_cliente && (
+          {/* Informações do cliente */}
+          <div className="text-sm text-muted-foreground flex flex-col gap-1">
             <span>
-              <strong>Endereço:</strong> {pedido.endereco_cliente}
+              <strong>Telefone:</strong> {pedido.telefone_cliente || "—"}
             </span>
-          )}
-          <span>
-            <strong>Meio de Pagamento:</strong>{" "}
-            {pedido.meio_pagamento_descricao || "—"}
-          </span>
-        </div>
+            {pedido.endereco_cliente && (
+              <span>
+                <strong>Endereço:</strong> {pedido.endereco_cliente}
+              </span>
+            )}
+            <span>
+              <strong>Meio de Pagamento:</strong> {pedido.meio_pagamento_descricao || "—"}
+            </span>
+            {(pedido.status === "S" || pedido.status === "E") && pedido.motoboy && (
+              <span>
+                <strong>Motoboy:</strong> {pedido.motoboy}
+              </span>
+            )}
+          </div>
 
-        {/* Valor total */}
-        <div className=" flex justify-between font-bold text-foreground">
-          R$ {pedido.valor_total.toFixed(2)}
-          <div className="flex gap-1">
-            <button className="bg-primary/20 text-primary rounded-full d px-2">
-              <Eye size={15} />
-            </button>
-            <button className="bg-primary/20 text-primary rounded-full px-2">
-              <Printer size={15} />
-            </button>
-            <button className="bg-primary/20 text-primary rounded-full px-2">
-              <ChevronRight size={15} />
-            </button>
+          {/* Valor total */}
+          <div className="flex justify-between font-bold text-foreground">
+            R$ {pedido.valor_total.toFixed(2)}
+            <div className="flex gap-1">
+              <button
+                className="bg-primary/20 text-primary rounded-full px-2 hover:bg-primary/30 transition-colors"
+                onClick={() => setIsModalOpen(true)}
+                title="Visualizar pedido"
+              >
+                <Eye size={15} />
+              </button>
+              <button className="bg-primary/20 text-primary rounded-full px-2 hover:bg-primary/30 transition-colors">
+                <Printer size={15} />
+              </button>
+              <button className="bg-primary/20 text-primary rounded-full px-2 hover:bg-primary/30 transition-colors">
+                <ChevronRight size={15} />
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    );
-  }
-);
 
-PedidoCard.displayName = "PedidoCard";
+        <PedidoModal pedido={pedido} isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+      </>
+    )
+  },
+)
+
+PedidoCard.displayName = "PedidoCard"
+

--- a/apps/supervisor/src/components/routes/pedidos/PedidoModal.tsx
+++ b/apps/supervisor/src/components/routes/pedidos/PedidoModal.tsx
@@ -1,0 +1,303 @@
+"use client"
+
+import type React from "react"
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../ui/dialog"
+import { Button } from "../../ui/button"
+import { Input } from "../../ui/input"
+import { Label } from "../../ui/label"
+import { Badge } from "../../ui/badge"
+import { Edit, Save, X, Phone, MapPin, CreditCard, Clock } from "lucide-react"
+import { useUpdatePedido } from "../../../services/useQueryPedidoAdmin"
+import type { PedidoKanban } from "../../../types/pedido"
+
+interface PedidoModalProps {
+  pedido: PedidoKanban | null
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const PedidoModal: React.FC<PedidoModalProps> = ({ pedido, isOpen, onClose }) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [formData, setFormData] = useState<any>({})
+  
+  const updatePedido = useUpdatePedido()
+
+  const canEdit = pedido?.status === "P" || pedido?.status === "R"
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case "P":
+        return "Pendente"
+      case "R":
+        return "Em Preparo"
+      case "S":
+        return "Saiu para Entrega"
+      case "E":
+        return "Entregue"
+      case "C":
+        return "Cancelado"
+      default:
+        return status
+    }
+  }
+
+  const getStatusVariant = (status: string) => {
+    switch (status) {
+      case "P":
+        return "destructive"
+      case "R":
+        return "default"
+      case "S":
+        return "secondary"
+      case "E":
+        return "default"
+      case "C":
+        return "destructive"
+      default:
+        return "default"
+    }
+  }
+
+  useEffect(() => {
+
+    console.log(pedido)
+    if (pedido) {
+      console.log("[v0] Usando dados do pedido:", pedido)
+
+      setFormData({
+        nome_cliente: (pedido as any).nome_cliente || "",
+        telefone_cliente: (pedido as any).telefone_cliente || "",
+        endereco_cliente: (pedido as any).endereco_cliente || "",
+        observacao_geral: (pedido as any).observacao_geral || "",
+        meio_pagamento_descricao: (pedido as any).meio_pagamento_descricao || "",
+      })
+    }
+  }, [pedido])
+
+  const handleSave = async () => {
+    if (!pedido) return
+
+    try {
+      await updatePedido.mutateAsync({
+        pedidoId: pedido.id,
+        data: formData,
+      })
+      setIsEditing(false)
+    } catch (error) {
+      console.error("[v0] Erro ao atualizar pedido:", error)
+    }
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+    if (pedido) {
+      setFormData({
+        nome_cliente: (pedido as any).nome_cliente || "",
+        telefone_cliente: (pedido as any).telefone_cliente || "",
+        endereco_cliente: (pedido as any).endereco_cliente || "",
+        observacao_geral: (pedido as any).observacao_geral || "",
+        meio_pagamento_descricao: (pedido as any).meio_pagamento_descricao || "",
+      })
+    }
+  }
+
+  if (!pedido) return null
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader className="pb-4 border-b">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <DialogTitle className="text-2xl font-bold">Pedido #{pedido.id}</DialogTitle>
+              <Badge variant={getStatusVariant(pedido.status)} className="text-sm px-3 py-1">
+                {getStatusText(pedido.status)}
+              </Badge>
+            </div>
+
+            <div className="flex gap-2">
+              {canEdit && !isEditing && (
+                <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
+                  <Edit className="w-4 h-4 mr-2" />
+                  Editar
+                </Button>
+              )}
+
+              {isEditing && (
+                <>
+                  <Button variant="outline" size="sm" onClick={handleCancel}>
+                    <X className="w-4 h-4 mr-2" />
+                    Cancelar
+                  </Button>
+                  <Button size="sm" onClick={handleSave} disabled={updatePedido.isPending}>
+                    <Save className="w-4 h-4 mr-2" />
+                    {updatePedido.isPending ? "Salvando..." : "Salvar"}
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-8 py-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {/* Coluna Esquerda */}
+            <div className="space-y-6">
+              {/* Informações do Cliente */}
+              <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold flex items-center gap-2 text-gray-800">
+                  <Phone className="w-5 h-5 text-blue-600" />
+                  Informações do Cliente
+                </h3>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="nome_cliente" className="text-sm font-medium">
+                      Nome do Cliente
+                    </Label>
+                    <Input
+                      id="nome_cliente"
+                      value={formData.nome_cliente || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, nome_cliente: e.target.value }))}
+                      disabled={!isEditing}
+                      className="bg-white"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="telefone_cliente" className="text-sm font-medium">
+                      Telefone
+                    </Label>
+                    <Input
+                      id="telefone_cliente"
+                      value={formData.telefone_cliente || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, telefone_cliente: e.target.value }))}
+                      disabled={!isEditing}
+                      className="bg-white"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Endereço */}
+              <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold flex items-center gap-2 text-gray-800">
+                  <MapPin className="w-5 h-5 text-green-600" />
+                  Endereço de Entrega
+                </h3>
+
+                <div className="space-y-2">
+                  <Label htmlFor="endereco_cliente" className="text-sm font-medium">
+                    Endereço Completo
+                  </Label>
+                  <textarea
+                    id="endereco_cliente"
+                    value={formData.endereco_cliente || ""}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, endereco_cliente: e.target.value }))}
+                    disabled={!isEditing}
+                    rows={4}
+                    className="flex min-h-[100px] w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                  />
+                </div>
+              </div>
+
+              {/* Observações */}
+              <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold text-gray-800">Observações</h3>
+
+                <div className="space-y-2">
+                  <textarea
+                    value={formData.observacao_geral || ""}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, observacao_geral: e.target.value }))}
+                    disabled={!isEditing}
+                    rows={4}
+                    placeholder="Observações do pedido..."
+                    className="flex min-h-[100px] w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Coluna Direita */}
+            <div className="space-y-6">
+              {/* Pagamento */}
+              <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold flex items-center gap-2 text-gray-800">
+                  <CreditCard className="w-5 h-5 text-purple-600" />
+                  Pagamento
+                </h3>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="meio_pagamento_descricao" className="text-sm font-medium">
+                      Meio de Pagamento
+                    </Label>
+                    <Input
+                      id="meio_pagamento_descricao"
+                      value={formData.meio_pagamento_descricao || ""}
+                      onChange={(e) => setFormData((prev:any) => ({ ...prev, meio_pagamento_descricao: e.target.value }))}
+                      disabled={!isEditing}
+                      className="bg-white"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Valor Total</Label>
+                    <Input
+                      value={`R$ ${((pedido as any).valor_total || 0).toFixed(2)}`}
+                      disabled
+                      className="bg-white font-semibold text-lg text-green-700"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Tempo do Pedido */}
+              <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold flex items-center gap-2 text-gray-800">
+                  <Clock className="w-5 h-5 text-orange-600" />
+                  Informações do Pedido
+                </h3>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Data/Hora do Pedido</Label>
+                    <Input
+                      value={
+                        (pedido as any).data_criacao
+                          ? new Date((pedido as any).data_criacao).toLocaleString("pt-BR")
+                          : ""
+                      }
+                      disabled
+                      className="bg-white"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Tempo Decorrido</Label>
+                    <Input value={`${pedido.tempo_minutos || 0} minutos`} disabled className="bg-white font-semibold" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {!canEdit && (
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mt-6">
+              <div className="flex items-start gap-3">
+                <div className="w-5 h-5 text-amber-600 mt-0.5">⚠️</div>
+                <div>
+                  <p className="text-sm text-amber-800 font-medium">Pedido não editável</p>
+                  <p className="text-sm text-amber-700 mt-1">
+                    Apenas pedidos com status "Pendente" ou "Em Preparo" podem ser modificados.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/supervisor/src/services/useCurrentUser.jsx
+++ b/apps/supervisor/src/services/useCurrentUser.jsx
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+import { mensuraApi } from "@supervisor/api/MensuraApi"
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: ["currentUser"],
+    queryFn: () => mensuraApi.auth.obterUsuarioAtualApiAuthMeGet(),
+    staleTime: 5 * 60 * 1000, // 5 minutos
+    retry: 1,
+  })
+}

--- a/apps/supervisor/src/services/useQueryPedidoAdmin.ts
+++ b/apps/supervisor/src/services/useQueryPedidoAdmin.ts
@@ -1,50 +1,51 @@
 // src/services/usePedidosAdmin.ts
-import apiMensura from "@supervisor/lib/api/apiMensura";
-import {
-  PedidoKanban,
-  PedidoStatus,
-  PagamentoMetodo,
-  PagamentoGateway,
-} from "@supervisor/types/pedido";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useToast } from "@supervisor/hooks/use-toast";
-import { getErrorMessage } from "@supervisor/lib/getErrorMessageOrizon";
+import apiMensura from "@supervisor/lib/api/apiMensura"
+import type { PedidoKanban, PedidoStatus, PagamentoMetodo, PagamentoGateway } from "@supervisor/types/pedido"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useToast } from "@supervisor/hooks/use-toast"
+import { getErrorMessage } from "@supervisor/lib/getErrorMessageOrizon"
 
-export function useFetchPedidosAdminKanban(date: string) {
+export function useFetchPedidosAdminKanban(date: string, empresaId?: string) {
   return useQuery<PedidoKanban[]>({
-    queryKey: ["pedidosAdminKanban", date], // 👈 cache separado por dia
+    queryKey: ["pedidosAdminKanban", date, empresaId],
     queryFn: async () => {
-      const { data } = await apiMensura.get(
-        `/api/delivery/pedidos/admin/kanban?date_filter=${date}`
-      );
-      return data;
+      let url = `/api/delivery/pedidos/admin/kanban?date_filter=${date}`
+
+      if (empresaId) {
+        url += `&empresa_id=${empresaId}`
+        console.log("[v0] URL da requisição:", url)
+      } else {
+        console.log("[v0] ERRO: empresa_id é obrigatório mas não foi fornecido")
+        throw new Error("empresa_id é obrigatório")
+      }
+
+      const { data } = await apiMensura.get(url)
+      return data
     },
     refetchInterval: 15000,
-  });
+    enabled: !!empresaId,
+  })
 }
 
 export function useMutatePedidoAdmin() {
-  const qc = useQueryClient();
-  const { toast } = useToast();
+  const qc = useQueryClient()
+  const { toast } = useToast()
 
-  const invalidate = () =>
-    qc.invalidateQueries({ queryKey: ["pedidosAdminKanban"], exact: false });
+  const invalidate = () => qc.invalidateQueries({ queryKey: ["pedidosAdminKanban"], exact: false })
 
   const atualizarStatus = useMutation({
     mutationFn: async ({ id, status }: { id: number; status: PedidoStatus }) => {
-      const { data } = await apiMensura.put(
-        `/api/delivery/pedidos/status/${id}?status=${status}`
-      );
-      return data;
+      const { data } = await apiMensura.put(`/api/delivery/pedidos/status/${id}?status=${status}`)
+      return data
     },
     onSuccess: () => {
-      toast({ title: "Pedido atualizado", description: "O status do pedido foi atualizado com sucesso." });
-      invalidate();
+      toast({ title: "Pedido atualizado", description: "O status do pedido foi atualizado com sucesso." })
+      invalidate()
     },
     onError: (err: any) => {
-      toast({ title: "Erro ao atualizar pedido", description: getErrorMessage(err), variant: "destructive"  });
+      toast({ title: "Erro ao atualizar pedido", description: getErrorMessage(err), variant: "destructive" })
     },
-  });
+  })
 
   const confirmarPagamento = useMutation({
     mutationFn: async ({
@@ -52,24 +53,54 @@ export function useMutatePedidoAdmin() {
       metodo,
       gateway,
     }: {
-      id: number;
-      metodo?: PagamentoMetodo;
-      gateway?: PagamentoGateway;
+      id: number
+      metodo?: PagamentoMetodo
+      gateway?: PagamentoGateway
     }) => {
-      const { data } = await apiMensura.post(
-        `/api/delivery/pedidos/${id}/confirmar-pagamento`,
-        { metodo, gateway }
-      );
-      return data;
+      const { data } = await apiMensura.post(`/api/delivery/pedidos/${id}/confirmar-pagamento`, { metodo, gateway })
+      return data
     },
     onSuccess: () => {
-      toast({ title: "Pagamento confirmado", description: "O pagamento do pedido foi confirmado com sucesso." });
-      invalidate();
+      toast({ title: "Pagamento confirmado", description: "O pagamento do pedido foi confirmado com sucesso." })
+      invalidate()
     },
     onError: (err: any) => {
-      toast({ title: "Erro ao confirmar pagamento", description: getErrorMessage(err), variant: "destructive"  });
+      toast({ title: "Erro ao confirmar pagamento", description: getErrorMessage(err), variant: "destructive" })
     },
-  });
+  })
 
-  return { atualizarStatus, confirmarPagamento };
+  return { atualizarStatus, confirmarPagamento }
+}
+
+export function useFetchPedidoDetalhes(pedidoId: number | null) {
+  return useQuery({
+    queryKey: ["pedidoDetalhes", pedidoId],
+    queryFn: async () => {
+      if (!pedidoId) return null
+      const { data } = await apiMensura.get(`/api/delivery/pedidos/${pedidoId}`)
+      console.log(data)
+      return data
+    },
+    enabled: !!pedidoId,
+  })
+}
+
+export function useUpdatePedido() {
+  const qc = useQueryClient()
+  const { toast } = useToast()
+
+  return useMutation({
+    mutationFn: async ({ pedidoId, data }: { pedidoId: number; data: any }) => {
+      const response = await apiMensura.put(`/api/delivery/pedidos/${pedidoId}`, data)
+      return response.data
+    },
+    onSuccess: () => {
+      toast({ title: "Pedido atualizado", description: "As informações do pedido foram atualizadas com sucesso." })
+      qc.invalidateQueries({ queryKey: ["pedidosAdminKanban"], exact: false })
+      qc.invalidateQueries({ queryKey: ["pedidoDetalhes"], exact: false })
+    },
+    onError: (err: any) => {
+      toast({ title: "Erro ao atualizar pedido", description: getErrorMessage(err), variant: "destructive" })
+    },
+  })
 }

--- a/apps/supervisor/src/types/pedido.ts
+++ b/apps/supervisor/src/types/pedido.ts
@@ -1,18 +1,39 @@
+// // ================= Enums =================
+// export type PedidoStatus = "P" | "R" | "E" | "S" | "C"; // Pendente,  Em preparo, Entregue, Saiu para entrega, cancelado
+// export type TipoEntrega = "DELIVERY" | "RETIRADA";
+// export type OrigemPedido = "WEB" | "APP" | "PDV";
+// export type PagamentoMetodo = "DINHEIRO" | "CARTAO" | "PIX";
+// export type PagamentoGateway = "PIX_INTERNO" | "PAGSEGURO" | "STRIPE";
+
+// export type PedidoKanban = {
+//   id: number;
+//   status: "P" | "R" | "S" | "E" | "C";
+//   telefone_cliente?: string | null;
+//   nome_cliente?: string | null;   // novo campo
+//   valor_total: number;
+//   data_criacao: string;
+//   endereco_cliente?: string | null;     // novo campo
+//   meio_pagamento_descricao: string | null
+//   observacao_geral: string | null
+// };
+
 // ================= Enums =================
-export type PedidoStatus = "P" | "R" | "E" | "S" | "C"; // Pendente,  Em preparo, Entregue, Saiu para entrega, cancelado
-export type TipoEntrega = "DELIVERY" | "RETIRADA";
-export type OrigemPedido = "WEB" | "APP" | "PDV";
-export type PagamentoMetodo = "DINHEIRO" | "CARTAO" | "PIX";
-export type PagamentoGateway = "PIX_INTERNO" | "PAGSEGURO" | "STRIPE";
+export type PedidoStatus = "P" | "R" | "E" | "S" | "C" // Pendente, Em preparo, Entregue, Saiu para entrega, cancelado
+export type TipoEntrega = "DELIVERY" | "RETIRADA"
+export type OrigemPedido = "WEB" | "APP" | "PDV"
+export type PagamentoMetodo = "DINHEIRO" | "CARTAO" | "PIX"
+export type PagamentoGateway = "PIX_INTERNO" | "PAGSEGURO" | "STRIPE"
 
 export type PedidoKanban = {
-  id: number;
-  status: "P" | "R" | "S" | "E" | "C";
-  telefone_cliente?: string | null;
-  nome_cliente?: string | null;   // novo campo
-  valor_total: number;
-  data_criacao: string;
-  endereco_cliente?: string | null;     // novo campo
+  id: number
+  status: "P" | "R" | "S" | "E" | "C"
+  telefone_cliente?: string | null
+  nome_cliente?: string | null // novo campo
+  valor_total: number
+  data_criacao: string
+  endereco_cliente?: string | null // novo campo
   meio_pagamento_descricao: string | null
   observacao_geral: string | null
-};
+  motoboy?: string | null // Adicionando campo motoboy para filtros
+  empresa_id?: number | null // Adicionando empresa_id para filtros
+}


### PR DESCRIPTION
## 🚀 Funcionalidades Implementadas

### Filtros do Kanban
- ✅ Filtro por empresa (select com empresas do usuário)
- ✅ Filtro por número do pedido
- ✅ Filtro por telefone do cliente  
- ✅ Filtro por nome do cliente
- ✅ Filtro por motoboy (apenas para "Saiu para entrega" e "Entregue")
- ✅ Badges de filtros ativos com remoção individual
- ✅ Botão "Limpar Filtros"

### Modal de Pedidos
- ✅ Visualização completa das informações do pedido
- ✅ Edição habilitada apenas para pedidos "Pendente" ou "Em Preparo"
- ✅ Layout responsivo e profissional
- ✅ Integração com API correta

### Melhorias Técnicas
- ✅ Correção de tipos TypeScript
- ✅ Integração com API usando empresa_id obrigatório
- ✅ Componentes shadcn/ui para melhor UX
- ✅ Tratamento de erros e loading states

## 🧪 Como Testar
1. Acesse a página de pedidos
2. Teste os filtros individualmente e em combinação
3. Clique no ícone de visualização em qualquer pedido
4. Teste a edição em pedidos pendentes/em preparo